### PR TITLE
Gh 791 add named operation group label & black/whitelist (#830)

### DIFF
--- a/cd/verify.sh
+++ b/cd/verify.sh
@@ -10,13 +10,12 @@ if [[ "$RELEASE" != 'true' ]] && [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
         mvn -q -nsu verify -P travis,test -B
     elif [[ "$MODULES" == 'analytics-ui' ]]; then
         # It would be good to move these into the pre-install and install phases. For now though, it works.
-
         # Install node version manager
         wget https://raw.githubusercontent.com/creationix/nvm/v0.31.0/nvm.sh -O ~/.nvm/nvm.sh
         source ~/.nvm/nvm.sh
 
         # Update nodejs to the latest version
-        nvm install node
+        nvm install 13.13.0
 
         # Install the Analytics UI
         cd analytics/analytics-ui

--- a/ui/src/main/webapp/app/query/operation-chain-component.js
+++ b/ui/src/main/webapp/app/query/operation-chain-component.js
@@ -33,7 +33,19 @@ function OperationChainController(operationChain, settings, config, loading, que
     vm.enableChainSaving;
     vm.namedOperation = {
         name: null,
-        description: null
+        description: null,
+        labels: '',
+    }
+
+    vm.namedOperation.getLabelsList = function() {
+        if(vm.namedOperation.labels) {
+            var labelsList = vm.namedOperation.labels.split('\n');
+            return labelsList.map(function(label) {
+                return label.trim();
+            });
+        } else {
+            return [];
+        }
     }
     vm.updatedQuery = {
         name: null,
@@ -170,20 +182,21 @@ function OperationChainController(operationChain, settings, config, loading, que
         }
 
         var confirm = $mdDialog.confirm()
-        .title('Operation chain saved as named operation!')
-        .textContent('You can now see your saved operation in the list of operations')
-        .ok('Ok')
+            .title('Operation chain saved as named operation!')
+            .textContent('You can now see your saved operation in the list of operations')
+            .ok('Ok');
 
         var invalidName = $mdDialog.confirm()
-        .title('Operation chain name is invalid!')
-        .textContent('You must provide a name for the operation')
-        .ok('Ok')
+            .title('Operation chain name is invalid!')
+            .textContent('You must provide a name for the operation')
+            .ok('Ok');
 
         if (vm.namedOperation.name != null && vm.namedOperation.name != '') {
             query.executeQuery(
                 {
                     class: ADD_NAMED_OPERATION_CLASS,
                     operationName: vm.namedOperation.name,
+                    labels: vm.namedOperation.getLabelsList(),
                     operationChain: chain,
                     description: vm.namedOperation.description,
                     options: {},

--- a/ui/src/main/webapp/app/query/operation-selector/operation-selector.html
+++ b/ui/src/main/webapp/app/query/operation-selector/operation-selector.html
@@ -21,9 +21,12 @@
                     md-menu-class="named-view-template"
                     md-dropdown-items="10">
                 <md-item-template>
-                    <div class="md-body-2" md-highlight-flags="i">{{op.name}}
-                    </div>
-                    <em class="md-body-1" md-highlight-flags="i">{{op.description}}</em>
+                    <div class="md-body-2" md-highlight-flags="i">{{op.name}}</div>
+                    <em class="md-body-1" md-highlight-flags="i">
+                        {{op.description}}
+                        <br ng-if="op.description && op.labels" />
+                        {{op.labels ? 'Labels: #' + op.labels.join(' #') : ''}}
+                    </em>
                 </md-item-template>
                 <div ng-messages="ctrl.operationForm.autocomplete.$error">
                     <div ng-message="required">You must select an operation

--- a/ui/src/main/webapp/app/query/save-sidenav/save-sidenav-component.js
+++ b/ui/src/main/webapp/app/query/save-sidenav/save-sidenav-component.js
@@ -16,6 +16,9 @@
 
 'use strict';
 
+function SaveSidenavController() {
+}
+
 angular.module('app').component('saveSidenav', saveSidenav());
 
 function saveSidenav() {
@@ -29,7 +32,4 @@ function saveSidenav() {
             onSave: '&',            // a function to save the named operation
         }
     }
-}
-
-function SaveSidenavController() {
 }

--- a/ui/src/main/webapp/app/query/save-sidenav/save-sidenav.html
+++ b/ui/src/main/webapp/app/query/save-sidenav/save-sidenav.html
@@ -8,23 +8,40 @@
                 <md-input-container class="md-block">
                     <label for="saved-name">Name</label>
                     <input type="text" id="saved-name" required ng-model="ctrl.namedOperation.name" md-autofocus>
-                </md-input-container>     
+                </md-input-container>
             </div>
             <div width='100%'>
                 <md-input-container class="md-block">
                     <label for="saved-description" required>Description</label>
-                    <textarea 
+                    <textarea
                         id="saved-description"
                         md-no-autogrow
                         ng-model="ctrl.namedOperation.description"
                         rows="3"
-                    >
-                    </textarea>
+                    ></textarea>
                 </md-input-container>
             </div>
-            <div layout="row" class="content">
-                <md-button id="close-save-sidenav" ng-click="ctrl.onClose()" class="md-primary">Close</md-button>
-                <md-button id="save-named-operation" ng-click="ctrl.onSave()" class="md-primary">Save</md-button>
+            <div width='100%'>
+                <md-input-container class="md-block">
+                    <label for="saved-label">Label Tags <i>(list each label on new line)</i></label>
+                    <textarea
+                        id="saved-label"
+                        md-no-autogrow
+                        ng-model="ctrl.namedOperation.labels"
+                        rows="3"
+                    ></textarea>
+                    <md-list class="no-vertical-padding layout-column">
+                    <md-list-item class="md-2-line">
+                        <div class="md-list-item-text">
+                            <p>{{ctrl.namedOperation.labels ? 'Tagged: #' + ctrl.namedOperation.getLabelsList().join(' #') : ''}}</p>
+                        </div>
+                    </md-list-item>
+                    </md-list>
+                </md-input-container>
+            </div>
+            <div layout="row" layout-align="space-between" class="content">
+                <md-button id="close-save-sidenav" ng-click="ctrl.onClose()" class="md-raised">Close</md-button>
+                <md-button id="save-named-operation" ng-click="ctrl.onSave()" class="md-primary md-raised" >Save</md-button>
             </div>
         </form>
     </md-content>

--- a/ui/src/test/webapp/app/gaffer/is-allowed-operation-service-spec.js
+++ b/ui/src/test/webapp/app/gaffer/is-allowed-operation-service-spec.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('isAllowedOperation', function() {
+
+    var service;
+
+    beforeEach(module('app'));
+
+    beforeEach(inject(function(_operationService_){
+        service = _operationService_;
+    }));
+
+    describe('Whitelist should override Blacklist', function() {
+
+        it('should return true, when Operation has a blacklisted and whitelisted labels', function() {
+            var operation = {
+                name: 'AnyName', labels: ['Whitelist Label', 'Blacklist label']
+            };
+            var configOperations = {
+                whiteList: ['Whitelist Label'], blackList:['Blacklist label']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true, when name blacklisted and label whitelisted', function() {
+            var operation = {
+                name: 'BlacklistedName', labels: ['OverridingLabel']
+            };
+            var configOperations = {
+                whiteList: ['OverridingLabel'], blackList:['BlacklistedName']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true, when name whitelisted and label blacklisted', function() {
+            var operation = {
+                name: 'OverridingName', labels: ['BlacklistedLabel']
+            };
+            var configOperations = {
+                whiteList: ['OverridingName'], blackList:['BlacklistedLabel']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+    });
+
+    describe('Blacklist and non-specified combinations should not be allow', function() {
+
+        it('should return false, when Op name & label both blacklisted', function() {
+            var operation = {
+                name: 'IllegalOperation', labels: ['Illegal Label']
+            };
+            var configOperations = {
+                whiteList: [], blackList:['IllegalOperation', 'Illegal Label']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(false);
+        });
+
+        it('should return false, when Op label is blacklisted only', function() {
+            var operation = {
+                name: 'AnyOperation', labels: ['Illegal Label']
+            };
+            var configOperations = {
+                whiteList: [], blackList:['Illegal Label']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(false);
+        });
+
+        it('should return false, when Op name is blacklisted only', function() {
+            var operation = {
+                name: 'IllegalOperation', labels: []
+            };
+            var configOperations = {
+                whiteList: [], blackList:['IllegalOperation']
+            };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(false);
+        });
+    });
+
+    describe('Whitelist and non-specified combinations should allow', function() {
+
+        it('should return true, when Op name & label both whitelisted', function() {
+            var operation = {
+                name: 'OkOperation', labels: ['OkLabel']
+            };
+            var configOperations = { whiteList: ['OkOperation', 'OkLabel'], blackList: [] };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true, when Op name is whitelisted only', function() {
+            var operation = {
+                name: 'OkOperation', labels: []
+            };
+            var configOperations = { whiteList: ['OkOperation'], blackList: [] };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true, when Op label is whitelisted only', function() {
+            var operation = {
+                name: 'OkOperation', labels: ['OkLabel']
+            };
+            var configOperations = { whiteList: ['OkLabel'], blackList: [] };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+    });
+
+    describe('No specified config should allow', function() {
+
+        it('should return true by default when white/blacklist are empty', function() {
+            var operation = {
+                name: 'AnyOperation', labels: []
+            };
+            var configOperations = { whiteList: [], blackList: [] };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true by default when Operation labels is missing', function() {
+            var operation = {
+                name: 'AnyOperation'
+            };
+            var configOperations = { whiteList: ['ok'], blackList: ['illegal'] };
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true by default when no white/blacklist is defined and op has empty labels', function() {
+            var operation = {
+                name: 'AnyOperation', labels: ["AnyLabel"]
+            };
+            var configOperations = {};
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+
+        it('should return true by default when no white/blacklist is defined and op has labels', function() {
+            var operation = {
+                name: 'AnyOperation', labels: []
+            };
+            var configOperations = {};
+
+            expect(service.isAllowedOperation(operation, configOperations)).toBe(true);
+        });
+    });
+});

--- a/ui/src/test/webapp/app/query/operation-chain-component-spec.js
+++ b/ui/src/test/webapp/app/query/operation-chain-component-spec.js
@@ -357,33 +357,28 @@ describe('The operation chain component', function() {
         });
 
         it('should save using an add named operation query', function() {
-            var testName = 'test name';
-            var testDescription = 'test description';
-            var OPERATION_CHAIN_CLASS = "uk.gov.gchq.gaffer.operation.OperationChain";    
-            var chain = {
-                    class: OPERATION_CHAIN_CLASS,
-                    operations: []
-            }
-            const ADD_NAMED_OPERATION_CLASS = "uk.gov.gchq.gaffer.named.operation.AddNamedOperation";
-
             ctrl.operations.length = 1;
-            ctrl.namedOperation.name = testName;
-            ctrl.namedOperation.description = testDescription;
+            ctrl.namedOperation.name = 'Operation Name';
+            ctrl.namedOperation.labels = 'Group Label 1';
+            ctrl.namedOperation.description = 'A description';
+
+            ctrl.saveChain();
 
             var expectedQuery = {
-                class: ADD_NAMED_OPERATION_CLASS,
-                operationName: testName,
-                operationChain: chain,
-                description: testDescription,
+                class: 'uk.gov.gchq.gaffer.named.operation.AddNamedOperation',
+                operationName: 'Operation Name',
+                labels: ['Group Label 1'],
+                operationChain: {
+                    class: 'uk.gov.gchq.gaffer.operation.OperationChain',
+                    operations: []
+                },
+                description: 'A description',
                 options: {},
                 score: 1,
                 overwriteFlag: true,
             }
-            
-            ctrl.saveChain();
-
-            expect(query.executeQuery).toHaveBeenCalledWith(expectedQuery, jasmine.any(Function));    
-        })
+            expect(query.executeQuery).toHaveBeenCalledWith(expectedQuery, jasmine.any(Function));
+        });
 
         it('should show a confirmation dialog', function() {
             ctrl.namedOperation.name = 'test name';
@@ -398,7 +393,7 @@ describe('The operation chain component', function() {
             ctrl.saveChain();
 
             expect($mdDialog.show).toHaveBeenCalledWith(confirm);
-        })
+        });
 
         it('should close the sidenav on success', function() {
             spyOn(ctrl, 'toggleSideNav').and.stub();
@@ -409,7 +404,7 @@ describe('The operation chain component', function() {
             ctrl.saveChain();
 
             expect(ctrl.toggleSideNav).toHaveBeenCalled();
-        })
+        });
 
         it('should reload the operations on success', function() {
             spyOn(operationService, 'reloadOperations').and.stub();
@@ -420,8 +415,8 @@ describe('The operation chain component', function() {
             ctrl.saveChain();
 
             expect(operationService.reloadOperations).toHaveBeenCalled();
-        })
-    })
+        });
+    });
 
     describe('ctrl.execute()', function() {
 
@@ -1893,9 +1888,24 @@ describe('The operation chain component', function() {
                 ctrl.resetChain();
                 scope.$digest();
 
-                expect(ctrl.operations).toEqual([1, 2 , 3]);
+                expect(ctrl.operations).toEqual([1, 2, 3]);
             });
 
         })
+    });
+
+    describe('ctrl.namedOperation.getLabelsList()', function() {
+        it('should return labels as a list when labels are inputted as a new line list', function() {
+            ctrl.namedOperation.labels = 'First label\nSecond label';
+
+            var expected = ['First label', 'Second label'];
+            expect(ctrl.namedOperation.getLabelsList()).toEqual(expected);
+        });
+        it('should trim each label and return as a list', function() {
+            ctrl.namedOperation.labels = 'End spaces   \n   Spaces at start';
+
+            var expected = ['End spaces', 'Spaces at start'];
+            expect(ctrl.namedOperation.getLabelsList()).toEqual(expected);
+        });
     });
 });

--- a/ui/src/test/webapp/app/query/operation-selector/operation-filter-spec.js
+++ b/ui/src/test/webapp/app/query/operation-selector/operation-filter-spec.js
@@ -25,12 +25,10 @@ describe('the operation filter', function() {
             {
                 formattedName: 'test',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'similar to test',
                 formattedDescription: ''
-            },
-            {
+            }, {
                 formattedName: 'unrelated',
                 formattedDescription: 'thing that has nothing to do with the first two'
             }
@@ -40,8 +38,7 @@ describe('the operation filter', function() {
             {
                 formattedName: 'test',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'similar to test',
                 formattedDescription: ''
             }
@@ -55,12 +52,10 @@ describe('the operation filter', function() {
             {
                 formattedName: 'test',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'similar to test',
                 formattedDescription: ''
-            },
-            {
+            }, {
                 formattedName: 'unrelated',
                 formattedDescription: 'thing that has nothing to do with the first two'
             }
@@ -81,12 +76,10 @@ describe('the operation filter', function() {
             {
                 formattedName: 'test',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'similar to test',
                 formattedDescription: ''
-            },
-            {
+            }, {
                 formattedName: 'unrelated',
                 formattedDescription: 'thing that has nothing to do with the first two'
             }
@@ -100,12 +93,10 @@ describe('the operation filter', function() {
             {
                 formattedName: 'foo',
                 formattedDescription: 'a foo operation'
-            },
-            {
+            }, {
                 formattedName: 'bar',
                 formattedDescription: ''
-            },
-            {
+            }, {
                 formattedName: 'test',
                 formattedDescription: 'a test operation'
             }
@@ -127,12 +118,10 @@ describe('the operation filter', function() {
             {
                 formattedName: 'similar to test',
                 formattedDescription: 'keyword in the description'
-            },
-            {
+            }, {
                 formattedName: 'test keyword',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'unrelated',
                 formattedDescription: 'thing that has nothing to do with the first two'
             }
@@ -142,14 +131,102 @@ describe('the operation filter', function() {
             {
                 formattedName: 'test keyword',
                 formattedDescription: 'an operation'
-            },
-            {
+            }, {
                 formattedName: 'similar to test',
                 formattedDescription: 'keyword in the description'
             },
-        ]
+        ];
 
         expect(operationFilter(ops, 'keyword')).toEqual(expected);
     });
 
+    it('should filter grouped NamedOperations by using # search', function() {
+        var operations = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['group 1']
+        }, {
+            formattedName: 'No Labels Op',
+            formattedDescription : 'No Labels Op',
+            labels: []
+        }, {
+            formattedName: 'Undefined Labelled Op',
+            formattedDescription : 'Undefined Labelled Op',
+        }];
+
+        var expected = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['group 1']
+        }];
+        expect(operationFilter(operations, '#')).toEqual(expected);
+    });
+
+    it('should filter grouped NamedOperations by using # and part of the label name as search', function() {
+        var operations = [{
+            formattedName: 'Labelled Op',
+            formattedDescription: 'Labelled Op',
+            labels: ['group 1']
+        }, {
+        formattedName: 'Labelled Op',
+            formattedDescription: 'Labelled Op',
+            labels: ['bananas']
+        }, {
+            formattedName: 'No Labels Op',
+            formattedDescription: 'No Labels Op',
+            labels: []
+        }, {
+            formattedName: 'Undefined Labelled Op',
+            formattedDescription: 'Undefined Labelled Op',
+        }];
+
+        var expected = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['group 1']
+        }];
+        expect(operationFilter(operations, '#g')).toEqual(expected);
+    });
+
+    it('should filter group NamedOperations and ignore casing using the #search', function() {
+        var operations = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['group 1']
+        }, {
+            formattedName: 'No Labels Op',
+            formattedDescription : 'No Labels Op',
+            labels: ['GROUP 1']
+        }];
+
+        var expected = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['group 1']
+        }, {
+            formattedName: 'No Labels Op',
+            formattedDescription : 'No Labels Op',
+            labels: ['GROUP 1']
+        }];
+        expect(operationFilter(operations, '#group')).toEqual(expected);
+    });
+
+    it('should filter group NamedOperations and ignore spacing using the #search', function() {
+        var operations = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['Group 1']
+        }, {
+            formattedName: 'No Labels Op',
+            formattedDescription : 'No Labels Op',
+            labels: ['Group 2']
+        }];
+
+        var expected = [{
+            formattedName: 'Labelled Op',
+            formattedDescription : 'Labelled Op',
+            labels: ['Group 1']
+        }];
+        expect(operationFilter(operations, '#group1')).toEqual(expected);
+    });
 });

--- a/ui/src/test/webapp/app/query/operation-selector/operation-selector-component-spec.js
+++ b/ui/src/test/webapp/app/query/operation-selector/operation-selector-component-spec.js
@@ -1,31 +1,22 @@
 describe('Operation Selector Component', function() {
     
     var ctrl;
-
     var $componentController, $q;
     var scope;
     var operationService;
     var $routeParams;
 
-    var availableOperations = [
-        {name: "op Name 1", description: "OP description 1"},
-        {name: "op Name 2", description: "OP description 2"},
-        {name: "op Name 3", description: "OP description 3"}
-    ];
-    
     beforeEach(module('app'));
 
     beforeEach(module(function($provide) {
         $provide.factory('config', function($q) {
             var get = function() {
                 return $q.when({});
-            }
-
+            };
             return {
                 get: get
-            }
+            };
         });
-
         $provide.factory('schema', function($q) {
             return {
                 get: function() {
@@ -34,7 +25,6 @@ describe('Operation Selector Component', function() {
             }
         });
     }));
-        
 
     beforeEach(inject(function(_$componentController_, _$rootScope_, _$q_, _operationService_, _$routeParams_) {
         $componentController = _$componentController_;
@@ -48,41 +38,51 @@ describe('Operation Selector Component', function() {
         ctrl = $componentController('operationSelector', {$scope: scope});
     });
 
-    beforeEach(function() {
-        spyOn(operationService, 'reloadOperations').and.callFake(function() {
-            return $q.when(availableOperations);
-        });
-    })
-
     it('should exist', function() {
         expect(ctrl).toBeDefined();
     });
 
     describe('ctrl.getOperations()', function() {
+        it('should set placeholder with "(e.g. Get Elements)" when Get Elements is an operation', function() {
+            var operations = [
+              {name: 'Get Elements'},
+            ];
+            spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(operations));
 
-        it('should load the operations', function() {
-            var ctrl = $componentController('operationSelector', { $scope: scope });
             ctrl.getOperations();
-
             scope.$digest();
-            expect(operationService.reloadOperations).toHaveBeenCalledTimes(1);
+
+            expect(ctrl.placeholder).toBe('Search for an operation (e.g Get Elements)');
         });
+
+        it('should use #tag in placeholder if a NamedOperation has a label tag', function() {
+            var operations = [
+              {name: 'Get Elements'},
+              {name: 'Named Operation', labels: ['label']}
+            ];
+            spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(operations));
+
+            ctrl.getOperations();
+            scope.$digest();
+
+            expect(ctrl.placeholder).toBe('Search for an operation or #labeltag (e.g Get Elements, #MyLabelTag)');
+        });
+    });
+
+    describe('ctrl.getOperations()', function() {
 
         it('should select the operation defined in the query operation parameter', function() {
             $routeParams.operation = "operationX";
             var ctrl = $componentController('operationSelector', { $scope: scope });
             var availableOperations = [
-                {
-                    name: "GetElements"
-                },
-                {
-                    name: "operationX"
-                }
-            ]
+                {name: "GetElements"},
+                {name: "operationX"}
+            ];
             spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(availableOperations));
-            ctrl.getOperations();
 
+            ctrl.getOperations();
             scope.$digest();
+
             expect(ctrl.model.name).toEqual('operationX');
         });
 
@@ -90,17 +90,14 @@ describe('Operation Selector Component', function() {
             $routeParams.operation = "operation-x.";
             var ctrl = $componentController('operationSelector', { $scope: scope });
             var availableOperations = [
-                {
-                    name: "GetElements"
-                },
-                {
-                    name: "operationX"
-                }
-            ]
+                {name: "GetElements"},
+                {name: "operationX"}
+            ];
             spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(availableOperations));
-            ctrl.getOperations();
 
+            ctrl.getOperations();
             scope.$digest();
+
             expect(ctrl.model.name).toEqual('operationX');
         });
 
@@ -108,17 +105,14 @@ describe('Operation Selector Component', function() {
             $routeParams.op = "operationX";
             var ctrl = $componentController('operationSelector', { $scope: scope });
             var availableOperations = [
-                {
-                    name: "GetElements"
-                },
-                {
-                    name: "operationX"
-                }
-            ]
+                {name: "GetElements"},
+                {name: "operationX"}
+            ];
             spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(availableOperations));
-            ctrl.getOperations();
 
+            ctrl.getOperations();
             scope.$digest();
+
             expect(ctrl.model.name).toEqual('operationX');
         });
 
@@ -127,114 +121,197 @@ describe('Operation Selector Component', function() {
             var ctrl = $componentController('operationSelector', { $scope: scope });
             ctrl.selectedOp = undefined;
             var availableOperations = [
-                {
-                    name: "GetElements"
-                },
-                {
-                    name: "operationX"
-                }
-            ]
+                {name: "GetElements"},
+                {name: "operationX"}
+            ];
             spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(availableOperations));
-            ctrl.getOperations();
 
+            ctrl.getOperations();
             scope.$digest();
+
             expect(ctrl.model).not.toBeDefined();
+        });
+
+        it('should populate and sort operations as NamedOps first and in alphabetical name order', function() {
+            var operationsInWrongOrder = [
+                {namedOp: false, name: 'Get All Elements', description: 'Gets all elements'},
+                {namedOp: true, name: 'Op Name 4', description: 'OP description 4'},
+                {namedOp: true, name: 'Op Name 3', labels: null, description: 'OP description 3'},
+                {namedOp: true, name: 'Op Name 2', labels: ['Group 1'], description: 'OP description 2'},
+                {namedOp: true, name: 'Op Name 1', labels: ['Group 1'], description: 'OP description 1'}
+            ];
+            spyOn(operationService, 'getAvailableOperations').and.returnValue($q.when(operationsInWrongOrder));
+
+            ctrl.getOperations();
+            scope.$digest();
+
+            var firstOp = {namedOp: true, name: 'Op Name 1', labels: ['Group 1'], description: 'OP description 1', formattedName: 'opname1', formattedDescription: 'opdescription1'};
+            var secondOp = {namedOp: true, name: 'Op Name 2', labels: ['Group 1'], description: 'OP description 2', formattedName: 'opname2', formattedDescription: 'opdescription2'};
+            var thirdOp = {namedOp: true, name: 'Op Name 3', labels: null, description: 'OP description 3', formattedName: 'opname3', formattedDescription: 'opdescription3'};
+            var fourthOp = {namedOp: true, name: 'Op Name 4', description: 'OP description 4', formattedName: 'opname4', formattedDescription: 'opdescription4'};
+            var fifthOp = {namedOp: false, name: 'Get All Elements', description: 'Gets all elements', formattedName: 'getallelements', formattedDescription: 'getsallelements'};
+            expect(ctrl.availableOperations[0]).toEqual(firstOp);
+            expect(ctrl.availableOperations[1]).toEqual(secondOp);
+            expect(ctrl.availableOperations[2]).toEqual(thirdOp);
+            expect(ctrl.availableOperations[3]).toEqual(fourthOp);
+            expect(ctrl.availableOperations[4]).toEqual(fifthOp);
         });
     });
 
     describe('ctrl.reloadOperations()', function() {
 
+        var availableOperations = [];
+
         beforeEach(function() {
+            spyOn(operationService, 'reloadOperations').and.callFake(function() {
+                return $q.when(availableOperations);
+            });
+        });
+
+        it('should populate and sort operations as NamedOps first and in alphabetical name order', function() {
+            availableOperations = [
+                {namedOp: false, name: 'Get All Elements', description: 'Gets all elements'},
+                {namedOp: true, name: 'Op Name 4', description: 'OP description 4'},
+                {namedOp: true, name: 'Op Name 3', labels: null, description: 'OP description 3'},
+                {namedOp: true, name: 'Op Name 2', labels: ['Group 1'], description: 'OP description 2'},
+                {namedOp: true, name: 'Op Name 1', labels: ['Group 1'], description: 'OP description 1'}
+            ];
+
             ctrl.reloadOperations();
-        });
-
-        it('should refresh the operations', function() {
-            expect(operationService.reloadOperations).toHaveBeenCalled();
-        });
-
-        it('should update the list of available operations with the results', function() {
             scope.$digest();
-            expect(ctrl.availableOperations).toEqual([
-                {name: "op Name 1", description: "OP description 1", formattedName: "opname1", formattedDescription: "opdescription1"},
-                {name: "op Name 2", description: "OP description 2", formattedName: "opname2", formattedDescription: "opdescription2"},
-                {name: "op Name 3", description: "OP description 3", formattedName: "opname3", formattedDescription: "opdescription3"}
-            ]);
+
+            var firstOp = {namedOp: true, name: 'Op Name 1', labels: ['Group 1'], description: 'OP description 1', formattedName: 'opname1', formattedDescription: 'opdescription1'};
+            var secondOp = {namedOp: true, name: 'Op Name 2', labels: ['Group 1'], description: 'OP description 2', formattedName: 'opname2', formattedDescription: 'opdescription2'};
+            var thirdOp = {namedOp: true, name: 'Op Name 3', labels: null, description: 'OP description 3', formattedName: 'opname3', formattedDescription: 'opdescription3'};
+            var fourthOp = {namedOp: true, name: 'Op Name 4', description: 'OP description 4', formattedName: 'opname4', formattedDescription: 'opdescription4'};
+            var fifthOp = {namedOp: false, name: 'Get All Elements', description: 'Gets all elements', formattedName: 'getallelements', formattedDescription: 'getsallelements'};
+            expect(ctrl.availableOperations[0]).toEqual(firstOp);
+            expect(ctrl.availableOperations[1]).toEqual(secondOp);
+            expect(ctrl.availableOperations[2]).toEqual(thirdOp);
+            expect(ctrl.availableOperations[3]).toEqual(fourthOp);
+            expect(ctrl.availableOperations[4]).toEqual(fifthOp);
+        });
+    });
+
+    describe('ctrl.populateOperations()', function() {
+
+        it('should sort by name alphabetically', function() {
+            var operations = [
+                {name: 'B Operation', description: 'abc'},
+                {name: 'A Operation', description: 'xyz'}
+            ];
+
+            ctrl.populateOperations(operations);
+            scope.$digest();
+
+            expect(ctrl.availableOperations[0].name).toBe('A Operation');
+            expect(ctrl.availableOperations[1].name).toBe('B Operation');
         });
 
-        describe('should order by', function() {
-            it('named operation first', function() {
-                availableOperations = [
-                    {
-                        name: 'abc',
-                        description: 'abc'
-                    },
-                    {
-                        name: 'xyz',
-                        description: 'xyz',
-                        namedOp: true
-                    }
-                ];
+        it('should not sort by name when already alphabetical', function() {
+            var operations = [
+                {name: 'A Operation', description: 'xyz'},
+                {name: 'B Operation', description: 'abc'}
+            ];
 
-                ctrl.reloadOperations();
-                scope.$digest();
+            ctrl.populateOperations(operations);
+            scope.$digest();
 
-                expect(ctrl.availableOperations[0].name).toEqual('xyz');
-            });
+            expect(ctrl.availableOperations[0].name).toBe('A Operation');
+            expect(ctrl.availableOperations[1].name).toBe('B Operation');
+        });
 
-            it('operation name second', function() {
-                availableOperations = [
-                    {
-                        name: 'abc',
-                        description: 'xyz'
-                    },
-                    {
-                        name: 'xyz',
-                        description: 'abc'
-                    }
-                ];
+        it('should sort by description alpha when names are the same', function() {
+            var operations = [
+                {name: 'A Operation', description: 'xyz'},
+                {name: 'A Operation', description: 'abc'}
+            ];
 
-                ctrl.reloadOperations();
-                scope.$digest();
+            ctrl.populateOperations(operations);
+            scope.$digest();
 
-                expect(ctrl.availableOperations[0].name).toEqual('abc');
-            });
+            expect(ctrl.availableOperations[0].description).toBe('abc');
+            expect(ctrl.availableOperations[1].description).toBe('xyz');
+        });
 
-            it('operation description third', function() {
-                availableOperations = [
-                    {
-                        name: 'abc',
-                        description: 'xyz'
-                    },
-                    {
-                        name: 'abc',
-                        description: 'abc'
-                    }
-                ];
+        it('should sort Named Operations first before by alpha name', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc'},
+                {name: 'B Operation', description: 'abc', namedOp: true}
+            ];
 
-                ctrl.reloadOperations();
-                scope.$digest();
+            ctrl.populateOperations(operations);
+            scope.$digest();
 
-                expect(ctrl.availableOperations[0].description).toEqual('abc');
-            });
+            expect(ctrl.availableOperations[0].name).toBe('B Operation');
+            expect(ctrl.availableOperations[1].name).toBe('A Operation');
+        });
 
-            it('the order it came in if all the above are the equal', function() {
-                availableOperations = [
-                    {
-                        name: 'abc',
-                        description: 'abc',
-                        passed: true
-                    },
-                    {
-                        name: 'abc',
-                        description: 'abc'
-                    }
-                ];
+        it('should sort Named Operations labels by alpha', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc', labels: ['C', 'D', 'B', 'A']}
+            ];
 
-                ctrl.reloadOperations();
-                scope.$digest();
+            ctrl.populateOperations(operations);
+            scope.$digest();
 
-                expect(ctrl.availableOperations[0].passed).toBeTruthy();
-            });
+            expect(ctrl.availableOperations[0].labels).toEqual(['A', 'B', 'C', 'D']);
+        });
+
+        it('should sort by group labels first before name and undefined labels as last', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc'},
+                {name: 'B Operation', description: 'abc', labels: ['BBB']},
+                {name: 'C Operation', description: 'abc', labels: ['AAA']},
+            ];
+
+            ctrl.populateOperations(operations);
+            scope.$digest();
+
+            expect(ctrl.availableOperations[0].name).toBe('C Operation');
+            expect(ctrl.availableOperations[1].name).toBe('B Operation');
+            expect(ctrl.availableOperations[2].name).toBe('A Operation');
+        });
+
+        it('should sort by group labels first before name and empty labels as last', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc', labels: []},
+                {name: 'B Operation', description: 'abc', labels: ['BBB']},
+                {name: 'C Operation', description: 'abc', labels: ['AAA']}
+            ];
+
+            ctrl.populateOperations(operations);
+            scope.$digest();
+
+            expect(ctrl.availableOperations[0].name).toBe('C Operation');
+            expect(ctrl.availableOperations[1].name).toBe('B Operation');
+            expect(ctrl.availableOperations[2].name).toBe('A Operation');
+        });
+
+        it('should sort by next group label in the array when first labels are the same', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc', labels: ['AAA', 'CCC']},
+                {name: 'B Operation', description: 'abc', labels: ['AAA', 'BBB']}
+            ];
+
+            ctrl.populateOperations(operations);
+            scope.$digest();
+
+            expect(ctrl.availableOperations[0].name).toBe('B Operation');
+            expect(ctrl.availableOperations[1].name).toBe('A Operation');
+        });
+
+        it('should sort by next group label in the array when first labels are the same', function() {
+            var operations = [
+                {name: 'A Operation', description: 'abc', labels: ['BBB', 'CCC']},
+                {name: 'B Operation', description: 'abc', labels: ['CCC', 'BBB', 'AAA']}
+            ];
+
+            ctrl.populateOperations(operations);
+            scope.$digest();
+
+            expect(ctrl.availableOperations[0].name).toBe('B Operation');
+            expect(ctrl.availableOperations[1].name).toBe('A Operation');
         });
     });
 });


### PR DESCRIPTION
* Save operation label input

* Made label non-mandatory

* Amended test to query AddNamedOperation with label

* Fixed side-nav auto focus to name input

* Operation displayName includes group label prefix

* Refactored operation selector test

* Further refactoring operation selector test

* Display labels as label tags in dropdown

* Filter by #labels

* Input labels test

* Input labeltags to NamedOperation (improvement)

* Filter whitelist/blacklisted operations

* Added TRAVIS_NODE_VERSION=node to yml

* Updated Travis yml

* Revert travis yml and edit verify.sh

* Revert travis node version to 13.13.0 to fix Sass

* node --lts version

* node "lts" version

* Trigger new travis build

* Revert back to node v13

* Revert back to original, just node

* Revert back to 13.13.0

Co-authored-by: d47853 <d47853@users.noreply.github.com>